### PR TITLE
[doc] Use `RubyWasmVdom::DomParser` instead of `DomParser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can also write vdom with like jsx signature with `DomParser`
       }
 
       view = ->(state, actions) {
-        eval DomParser.parse(<<-DOM)
+        eval RubyWasmVdom::DomParser.parse(<<-DOM)
           <div>
             <button onclick='{->(e) { actions[:increment].call(state, nil) } }'>Click me!</button>
             <p>{"Count is #{state[:count]}"}</p>


### PR DESCRIPTION
Follow up for db870a5 and d516c17